### PR TITLE
Add missing template files

### DIFF
--- a/.github/workflows/deptry.yml
+++ b/.github/workflows/deptry.yml
@@ -13,5 +13,7 @@ jobs:
           python-version: '3.11'
       # Install deptry
       - run: pip install deptry
+      # Remove pyproject.toml so that deptry doesn't get confused
+      - run: rm pyproject.toml
       # Run deptry to check that all dependencies are present.
       - run: deptry .

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,0 +1,11 @@
+name: isort import check
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: isort/isort-action@v1
+        with:
+            requirements-files: "requirements.txt requirements-test.txt"

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,16 @@
+# .github/workflows/deploy-wiki.yml
+name: deploy-wiki
+on:
+  push:
+    branches: "main"
+    paths: wiki/**
+  workflow_dispatch:
+jobs:
+  deploy-wiki:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions4gh/configure-wiki@v1
+      - uses: actions4gh/deploy-wiki@v1

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_first_party=qcore,empirical,nshmdb,IM_calculation,mera

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "PACKAGE NAME HERE"
+authors = [
+    {name = "QuakeCoRE" },
+]
+description = "PACKAGE DESCRIPTION HERE"
+readme = "README.md"
+requires-python = ">=3.9"
+dynamic = ["version", "dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,1 @@
+Welcome to the wiki!


### PR DESCRIPTION
This adds three things:

1. A pyproject.toml file for installing newly created repos as a python package.
2. A wiki action to do allow for PR review of wikis.
3. An isort config and isort action to allow automated checking of import sorting. The config lets us tell isort what our first-party packages are so they are sorted correctly. So that @joelridden doesn't need to comment about sorting order in PRs anymore.