### PR TITLE
Replace configure-wiki action with a perl script

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions4gh/configure-wiki@v1
+      - run: perl -i -pe 's;(\[.*?\])\((?!https:\/\/)(.*?)\.md\);\1(\2);' wiki/*.md
       - uses: actions4gh/deploy-wiki@v1

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: perl -i -pe 's;(\[.*?\])\((?!https:\/\/)(.*?)\.md\);\1(\2);' wiki/*.md
+      - run: perl -i -pe 's;(\[.*?\])\((?!https:\/\/)(.*?)\.md\);\1(\2);g' wiki/*.md
       - uses: actions4gh/deploy-wiki@v1


### PR DESCRIPTION
This fixes a bug deploying the wiki where the configure-wiki action will crash and stop the wiki from deploying:

The point of this action is to convert links like `[link](Home.md)` (which are what you write to link files on your computer, and what is auto-completed for you when you type `Ho` in your editor), into a link that works in the wiki: `[link](Home)`. I think this is simple enough that we can just replace it with a perl regex and cover 98% of the functionality of the configure-wiki action.

For context, here is the error you get on the Mera repo deploying the wiki.
```
Run actions4gh/configure-wiki@v1
Processing /home/runner/work/mera/mera/wiki/Home.md
node:internal/url:1463
    throw new ERR_INVALID_URL_SCHEME('file');
          ^

TypeError [ERR_INVALID_URL_SCHEME]: The URL must be of scheme file
    at fileURLToPath (node:internal/url:1463:11)
    at file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:27849:35
    at overload (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25407:12)
    at node (link) (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25354:27)
    at node (emphasis) (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25369:61)
    at node (paragraph) (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25369:61)
    at node (root) (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25369:61)
    at visitParents (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25329:28)
    at visit (file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:25403:3)
    at file:///home/runner/work/_actions/actions4gh/configure-wiki/v1/dist/main.js:27847:3 {
  code: 'ERR_INVALID_URL_SCHEME'
}
```